### PR TITLE
[bugfix] Fix checksum validation always failing

### DIFF
--- a/exchangeString.mjs
+++ b/exchangeString.mjs
@@ -413,8 +413,10 @@ function isValidChecksum(buffer) {
     const crcIndex = buffer.byteLength - 4;
     const data = new Uint8Array(buffer, 0, crcIndex);
     const actual = new DataView(buffer).getUint32(crcIndex, true);
-
-    return crc32(data) == actual;
+    // Convert signed checksum to unsigned as per https://github.com/SheetJS/js-crc32?tab=readme-ov-file#signed-integers
+    const expected = crc32(data) >>> 0;
+    
+    return expected == actual;
 }
 
 export async function parse(exchangeStr) {


### PR DESCRIPTION
The `crc32` library returns a signed checksum but we're reading an unsigned `uint32` from the data view as our actual checksum value. This is causing the checksum validation to always fail as seen in issue #2.

Working live copy is available at https://glektarssza.github.io/factorio-exchange-string-parser/ for testing.

Will close #2.

Tested using the same exchange string from #2.

![Screenshot 2025-01-24 at 11 55 52 AM](https://github.com/user-attachments/assets/c031206f-9adc-4a4c-87d6-87e09f1ffcc0)